### PR TITLE
[codex] improve Nidus website and benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target
 #.idea/
 
 .opencode/
+node_modules/
 
 # Generated documentation website
 website/dist/

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "nidus-website",
+  "version": "1.0.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nidus-website",
+      "version": "1.0.4",
+      "devDependencies": {
+        "playwright": "1.61.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -6,8 +6,13 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "check-links": "node scripts/check-links.mjs",
+    "check-mobile": "node scripts/check-mobile-layout.mjs",
+    "check-seo": "node scripts/check-seo.mjs",
     "verify": "npm run build && npm run check-links",
-    "verify:domain": "NIDUS_SITE_BASE=/ NIDUS_SITE_DOMAIN=rustnidus.com npm run verify",
+    "verify:domain": "NIDUS_SITE_BASE=/ NIDUS_SITE_DOMAIN=rustnidus.com npm run verify && npm run check-seo",
     "verify:project": "NIDUS_SITE_BASE=/nidus/ npm run verify"
+  },
+  "devDependencies": {
+    "playwright": "1.61.1"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/build.mjs",
+    "check-benchmarks": "node scripts/check-benchmarks.mjs",
     "check-links": "node scripts/check-links.mjs",
     "check-mobile": "node scripts/check-mobile-layout.mjs",
     "check-seo": "node scripts/check-seo.mjs",
-    "verify": "npm run build && npm run check-links",
+    "verify": "npm run build && npm run check-links && npm run check-benchmarks",
     "verify:domain": "NIDUS_SITE_BASE=/ NIDUS_SITE_DOMAIN=rustnidus.com npm run verify && npm run check-seo",
     "verify:project": "NIDUS_SITE_BASE=/nidus/ npm run verify"
   },

--- a/website/scripts/build.mjs
+++ b/website/scripts/build.mjs
@@ -10,7 +10,9 @@ const SRC = path.join(WEBSITE, 'src');
 const DIST = path.join(WEBSITE, 'dist');
 const BASE = normalizeBase(process.env.NIDUS_SITE_BASE ?? '/');
 const SITE_DOMAIN = (process.env.NIDUS_SITE_DOMAIN ?? '').trim();
+const SITE_ORIGIN = SITE_DOMAIN ? `https://${SITE_DOMAIN}` : '';
 const RELEASE_VERSION = '1.0.4';
+const SITE_DESCRIPTION = 'Nidus is a modular Rust backend framework for explicit services, typed dependency injection, Axum routes, Tower middleware, OpenAPI, observability, testing, and installable adapters.';
 
 const docs = [
   {
@@ -107,6 +109,11 @@ function asset(name) {
   return href(`assets/${name}`);
 }
 
+function absoluteHref(slug = '') {
+  const path = href(slug);
+  return SITE_ORIGIN ? `${SITE_ORIGIN}${path}` : path;
+}
+
 function read(file) {
   return fs.readFileSync(path.join(ROOT, file), 'utf8');
 }
@@ -117,6 +124,70 @@ function escapeHtml(value) {
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;');
+}
+
+function escapeJsonForHtml(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function seoDescription(description) {
+  if (description.length >= 50) return description;
+  return `${description} Nidus docs for typed Rust services, explicit modules, Axum routing, and production backend composition.`;
+}
+
+function documentTitle(title) {
+  if (title === 'Nidus') return 'Nidus Rust backend framework';
+  if (title.length < 8) return `Nidus ${title} documentation`;
+  return `${title} · Nidus`;
+}
+
+function structuredData({ title, description, url, currentSlug, home }) {
+  const graph = [
+    {
+      '@type': 'WebSite',
+      '@id': `${absoluteHref()}#website`,
+      url: absoluteHref(),
+      name: 'Nidus',
+      description: SITE_DESCRIPTION,
+      inLanguage: 'en',
+    },
+    {
+      '@type': home ? 'SoftwareSourceCode' : 'TechArticle',
+      '@id': `${url}#content`,
+      name: title,
+      headline: title,
+      description,
+      url,
+      image: absoluteHref('assets/og-image.png'),
+      inLanguage: 'en',
+      isPartOf: { '@id': `${absoluteHref()}#website` },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Nidus',
+        url: absoluteHref(),
+        logo: {
+          '@type': 'ImageObject',
+          url: absoluteHref('assets/logo-mark-transparent.png'),
+        },
+      },
+      programmingLanguage: 'Rust',
+      codeRepository: 'https://github.com/vicotrbb/nidus',
+    },
+  ];
+
+  if (!home && currentSlug) {
+    graph.push({
+      '@type': 'BreadcrumbList',
+      '@id': `${url}#breadcrumb`,
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Nidus', item: absoluteHref() },
+        { '@type': 'ListItem', position: 2, name: 'Docs', item: absoluteHref('docs/') },
+        { '@type': 'ListItem', position: 3, name: title, item: url },
+      ],
+    });
+  }
+
+  return { '@context': 'https://schema.org', '@graph': graph };
 }
 
 function inline(md) {
@@ -563,7 +634,19 @@ Use \`moka\` for the default async cache backend. Add \`health\` when readiness 
 Nidus does not decide cache keys, TTL policy, invalidation semantics, or data consistency guarantees. Those remain application architecture decisions.`;
 }
 
-function pageShell({ title, description, body, currentSlug, home = false, toc = [] }) {
+function pageShell({ title, description, body, currentSlug, home = false, toc = [], noindex = false }) {
+  const metaTitle = documentTitle(title);
+  const metaDescription = seoDescription(description);
+  const canonicalPath = home || !currentSlug ? '' : `${currentSlug}/`;
+  const canonicalUrl = absoluteHref(canonicalPath);
+  const ogImage = absoluteHref('assets/og-image.png');
+  const jsonLd = structuredData({
+    title: metaTitle,
+    description: metaDescription,
+    url: canonicalUrl,
+    currentSlug,
+    home,
+  });
   const tocLinks = toc.length
     ? toc.map((item) => `<a class="toc-level-${item.level}" href="#${item.id}">${escapeHtml(item.title)}</a>`).join('')
     : '<span>No section headings</span>';
@@ -602,19 +685,40 @@ function pageShell({ title, description, body, currentSlug, home = false, toc = 
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${escapeHtml(title)} · Nidus</title>
-  <meta name="description" content="${escapeHtml(description)}">
-  <meta property="og:title" content="${escapeHtml(title)} · Nidus">
-  <meta property="og:description" content="${escapeHtml(description)}">
-  <meta property="og:image" content="${asset('og-image.png')}">
+  <title>${escapeHtml(metaTitle)}</title>
+  <meta name="application-name" content="Nidus">
+  <meta name="author" content="Nidus">
+  <meta name="description" content="${escapeHtml(metaDescription)}">
+  ${noindex ? '<meta name="robots" content="noindex, follow">' : '<meta name="robots" content="index, follow">'}
+  <link rel="canonical" href="${canonicalUrl}">
+  <link rel="alternate" hreflang="en" href="${canonicalUrl}">
+  <link rel="alternate" hreflang="x-default" href="${canonicalUrl}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Nidus">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:url" content="${canonicalUrl}">
+  <meta property="og:title" content="${escapeHtml(metaTitle)}">
+  <meta property="og:description" content="${escapeHtml(metaDescription)}">
+  <meta property="og:image" content="${ogImage}">
+  <meta property="og:image:secure_url" content="${ogImage}">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Nidus Rust backend framework">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(metaTitle)}">
+  <meta name="twitter:description" content="${escapeHtml(metaDescription)}">
+  <meta name="twitter:image" content="${ogImage}">
+  <meta name="twitter:image:alt" content="Nidus Rust backend framework">
   <link rel="icon" href="${asset('favicon-32.png')}" sizes="32x32">
   <link rel="apple-touch-icon" href="${asset('apple-touch-icon.png')}">
   <link rel="stylesheet" href="${href('styles.css')}">
+  <script type="application/ld+json">${escapeJsonForHtml(jsonLd)}</script>
 </head>
 <body class="${home ? 'home' : 'doc-page'}">
   <header class="site-header">
     <a class="brand" href="${href()}" aria-label="Nidus home">
-      <img src="${asset('logo-full-transparent.png')}" alt="" width="48" height="46">
+      <img src="${asset('logo-mark-transparent.png')}" alt="" width="48" height="46">
       <span>Nidus</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
@@ -715,6 +819,7 @@ cargo run`;
       <div class="hero-copy">
         <p class="eyebrow">Rust backend framework · ${RELEASE_VERSION}</p>
         <h1>Nidus</h1>
+        <img class="mobile-hero-mark" src="${asset('logo-full-transparent.png')}" alt="Nidus logo" width="280" height="298">
         <p class="hero-text">A modular Rust backend framework for explicit services: typed dependency injection, module graphs, Axum routes, Tower middleware, validation, OpenAPI, observability, testing, and installable adapters.</p>
         <div class="hero-actions">
           <a class="button primary" href="${href('docs/installation/')}">Get started</a>
@@ -890,10 +995,11 @@ function notFoundPage() {
   </main>`;
   return pageShell({
     title: 'Page not found',
-    description: 'Nidus documentation route not found.',
+    description: 'This Nidus documentation route was not found. Continue to the Rust backend framework docs, installation guide, examples, or API reference.',
     body,
     currentSlug: '',
     home: true,
+    noindex: true,
   });
 }
 
@@ -905,6 +1011,27 @@ function writeHtml(route, html) {
   const dir = path.join(DIST, route);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'index.html'), html);
+}
+
+function writeSeoFiles() {
+  if (!SITE_ORIGIN) return;
+
+  const pages = ['', ...docs.map((doc) => doc.slug)];
+  const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${pages.map((page) => `  <url>
+    <loc>${absoluteHref(page ? `${page}/` : '')}</loc>
+  </url>`).join('\n')}
+</urlset>
+`;
+  const robotsTxt = `User-agent: *
+Allow: /
+
+Sitemap: ${absoluteHref('sitemap.xml')}
+`;
+
+  fs.writeFileSync(path.join(DIST, 'sitemap.xml'), sitemapXml);
+  fs.writeFileSync(path.join(DIST, 'robots.txt'), robotsTxt);
 }
 
 function main() {
@@ -930,6 +1057,7 @@ function main() {
   if (SITE_DOMAIN) {
     fs.writeFileSync(path.join(DIST, 'CNAME'), `${SITE_DOMAIN}\n`);
   }
+  writeSeoFiles();
   fs.writeFileSync(path.join(DIST, 'site-map.json'), JSON.stringify({ base: BASE, domain: SITE_DOMAIN || null, pages: ['', ...docs.map((doc) => doc.slug)] }, null, 2));
   console.log(`Built Nidus site at ${path.relative(ROOT, DIST)} with base ${BASE}${SITE_DOMAIN ? ` and domain ${SITE_DOMAIN}` : ''}`);
 }

--- a/website/scripts/build.mjs
+++ b/website/scripts/build.mjs
@@ -634,7 +634,48 @@ Use \`moka\` for the default async cache backend. Add \`health\` when readiness 
 Nidus does not decide cache keys, TTL policy, invalidation semantics, or data consistency guarantees. Those remain application architecture decisions.`;
 }
 
-function pageShell({ title, description, body, currentSlug, home = false, toc = [], noindex = false }) {
+const benchmarkProfiles = [
+  ['ping', 'rust-nidus', '156.890883/s', '423.72us', '659.57us'],
+  ['ping', 'python-fastapi', '148.264889/s', '3.35ms', '4.22ms'],
+  ['ping', 'java-spring', '154.820432/s', '1.13ms', '1.88ms'],
+  ['ping', 'node-express', '155.442129/s', '1.08ms', '1.78ms'],
+  ['users', 'rust-nidus', '297.482161/s', '1.59ms', '3.45ms'],
+  ['users', 'python-fastapi', '278.858057/s', '3.32ms', '6.01ms'],
+  ['users', 'java-spring', '292.89576/s', '1.97ms', '3.82ms'],
+  ['users', 'node-express', '291.549083/s', '2.11ms', '4.31ms'],
+  ['projects', 'rust-nidus', '423.939646/s', '1.95ms', '3.46ms'],
+  ['projects', 'python-fastapi', '380.644823/s', '4.03ms', '7.17ms'],
+  ['projects', 'java-spring', '417.118223/s', '2.26ms', '4.17ms'],
+  ['projects', 'node-express', '414.234335/s', '2.37ms', '4.24ms'],
+  ['events', 'rust-nidus', '282.357362/s', '2.97ms', '4.07ms'],
+  ['events', 'python-fastapi', '267.55211/s', '4.5ms', '6.86ms'],
+  ['events', 'java-spring', '281.790144/s', '3.03ms', '4.22ms'],
+  ['events', 'node-express', '279.668233/s', '3.23ms', '4.65ms'],
+  ['mixed', 'rust-nidus', '232.594368/s', '2.72ms', '7.05ms'],
+  ['mixed', 'python-fastapi', '223.820298/s', '4.01ms', '8.35ms'],
+  ['mixed', 'java-spring', '232.940412/s', '2.7ms', '6.84ms'],
+  ['mixed', 'node-express', '230.302808/s', '3.03ms', '7.3ms'],
+];
+
+const benchmarkHighlights = [
+  ['Fastest ping latency', '423.72us', 'Rust/Nidus average on the read-only ping profile.'],
+  ['Zero failed requests', '0.00% failed', 'Every stack completed the k6 profiles without HTTP failures.'],
+  ['Best write-heavy profile', '423.94/s', 'Rust/Nidus on the projects flow under the paced workload.'],
+];
+
+function benchmarkRows() {
+  return benchmarkProfiles.map(([profile, stack, throughput, average, p95]) => `<tr>
+    <td>${profile}</td>
+    <td><code>${stack}</code></td>
+    <td>${throughput}</td>
+    <td>${average}</td>
+    <td>${p95}</td>
+    <td>0.00%</td>
+    <td>100.00%</td>
+  </tr>`).join('');
+}
+
+function pageShell({ title, description, body, currentSlug, home = false, standalone = false, toc = [], noindex = false }) {
   const metaTitle = documentTitle(title);
   const metaDescription = seoDescription(description);
   const canonicalPath = home || !currentSlug ? '' : `${currentSlug}/`;
@@ -675,6 +716,7 @@ function pageShell({ title, description, body, currentSlug, home = false, toc = 
         ['GitHub', 'https://github.com/vicotrbb/nidus'],
         ['crates.io', 'https://crates.io/crates/nidus-rs'],
         ['docs.rs', `https://docs.rs/nidus-rs/${RELEASE_VERSION}/nidus/`],
+        ['Benchmarks', href('benchmarks/')],
         ['Security', href('docs/security-notes/')],
       ],
     },
@@ -726,11 +768,12 @@ function pageShell({ title, description, body, currentSlug, home = false, toc = 
       <a href="${href('docs/')}">Docs</a>
       <a href="${href('docs/installation/')}">Install</a>
       <a href="${href('docs/examples/')}">Examples</a>
+      <a href="${href('benchmarks/')}">Benchmarks</a>
       <a href="${href('docs/api-reference/')}">API</a>
       <a href="https://github.com/vicotrbb/nidus">Source</a>
     </nav>
   </header>
-  ${home ? body : `<main class="docs-frame">
+  ${home || standalone ? body : `<main class="docs-frame">
     <aside class="docs-sidebar">
       <div class="docs-search">
         <label for="docs-filter">Search docs</label>
@@ -944,6 +987,22 @@ struct AppModule;</code></pre>
       </div>
     </section>
 
+    <section class="benchmark-teaser" aria-labelledby="benchmark-title">
+      <div class="benchmark-teaser-copy">
+        <p class="eyebrow">Benchmark evidence</p>
+        <h2 id="benchmark-title">Measured against production-shaped peers, with bounded claims.</h2>
+        <p>A homelab Kubernetes run compared Rust/Nidus, FastAPI, Spring Boot, and Express against the same PostgreSQL-backed endpoint contract. The run is intentionally conservative, but the latency story is clear.</p>
+        <a class="text-link" href="${href('benchmarks/')}">Read the full benchmark breakdown</a>
+      </div>
+      <div class="benchmark-ledger" aria-label="Benchmark highlights">
+        ${benchmarkHighlights.map(([label, value, detail]) => `<article>
+          <span>${label}</span>
+          <strong>${value}</strong>
+          <p>${detail}</p>
+        </article>`).join('')}
+      </div>
+    </section>
+
     <section class="proof-band" aria-labelledby="proof-title">
       <div class="section-heading">
         <p class="eyebrow">Release proof</p>
@@ -960,6 +1019,101 @@ struct AppModule;</code></pre>
     body,
     currentSlug: '',
     home: true,
+  });
+}
+
+function benchmarksPage() {
+  const body = `<main class="benchmark-page">
+    <section class="benchmark-hero" aria-labelledby="benchmark-page-title">
+      <div>
+        <p class="eyebrow">Benchmark evidence</p>
+        <h1 id="benchmark-page-title">Nidus Framework Benchmark</h1>
+        <p>Bounded homelab run comparing Rust/Nidus, FastAPI, Spring Boot, and Express with the same endpoint contract, PostgreSQL persistence, one replica, and a matched application deployment envelope.</p>
+      </div>
+      <aside class="benchmark-run-card" aria-label="Run summary">
+        <span>Run timestamp</span>
+        <strong>20260630T001754Z</strong>
+        <p>k6 ran inside the benchmark namespace with 8 VUs and 20s per stack/profile. All checks passed, and every HTTP failure rate was 0.00%.</p>
+      </aside>
+    </section>
+
+    <section class="benchmark-method" aria-labelledby="benchmark-method-title">
+      <div>
+        <p class="eyebrow">Method</p>
+        <h2 id="benchmark-method-title">Bounded homelab run, not a max-throughput or capacity ceiling.</h2>
+      </div>
+      <div class="benchmark-method-grid">
+        <article>
+          <h3>Same contract</h3>
+          <p>Each stack exposed ping, users, projects, events, search, and mixed-flow endpoints against PostgreSQL-backed application data.</p>
+        </article>
+        <article>
+          <h3>Same envelope</h3>
+          <p>Each app used one Kubernetes replica, ClusterIP service exposure, and the same application deployment shape.</p>
+        </article>
+        <article>
+          <h3>Paced profile</h3>
+          <p>The k6 harness used constant VUs and a short sleep per iteration to protect shared homelab workloads, so throughput is intentionally bounded.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="benchmark-results" aria-labelledby="benchmark-results-title">
+      <div class="benchmark-results-heading">
+        <div>
+          <p class="eyebrow">Results</p>
+          <h2 id="benchmark-results-title">Latency stayed low across every application-shaped profile.</h2>
+        </div>
+        <p>Rust/Nidus was the latency leader or effectively tied across the run. The mixed profile is close enough to treat as a tie with Java rather than a broad superiority claim.</p>
+      </div>
+      <div class="benchmark-table-wrap">
+        <table class="benchmark-table">
+          <thead>
+            <tr>
+              <th>Profile</th>
+              <th>Stack</th>
+              <th>req/s</th>
+              <th>avg latency</th>
+              <th>p95 latency</th>
+              <th>failed</th>
+              <th>checks</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${benchmarkRows()}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="benchmark-interpretation" aria-labelledby="benchmark-interpretation-title">
+      <div>
+        <p class="eyebrow">Interpretation</p>
+        <h2 id="benchmark-interpretation-title">What this proves, and what it does not.</h2>
+      </div>
+      <div class="benchmark-interpretation-list">
+        <article>
+          <h3>Supported claim</h3>
+          <p>Under this conservative Kubernetes workload, Nidus completed the shared contract with zero request failures and consistently low latency.</p>
+        </article>
+        <article>
+          <h3>Bounded claim</h3>
+          <p>The req/s values are end-to-end paced workload results. They should not be presented as absolute capacity numbers.</p>
+        </article>
+        <article>
+          <h3>Next proof layer</h3>
+          <p>A capacity study would remove pacing, run longer windows, repeat samples, and isolate bottlenecks with continuous profiling.</p>
+        </article>
+      </div>
+    </section>
+  </main>`;
+
+  return pageShell({
+    title: 'Benchmarks',
+    description: 'Nidus framework benchmark results from a bounded homelab Kubernetes run against FastAPI, Spring Boot, and Express.',
+    body,
+    currentSlug: 'benchmarks',
+    standalone: true,
   });
 }
 
@@ -1016,7 +1170,7 @@ function writeHtml(route, html) {
 function writeSeoFiles() {
   if (!SITE_ORIGIN) return;
 
-  const pages = ['', ...docs.map((doc) => doc.slug)];
+  const pages = ['', 'benchmarks', ...docs.map((doc) => doc.slug)];
   const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${pages.map((page) => `  <url>
@@ -1050,6 +1204,7 @@ function main() {
   fs.copyFileSync(path.join(SRC, 'app.js'), path.join(DIST, 'app.js'));
 
   fs.writeFileSync(path.join(DIST, 'index.html'), homePage());
+  writeHtml('benchmarks', benchmarksPage());
   for (const doc of docs) {
     writeHtml(doc.slug, docPage(doc));
   }
@@ -1058,7 +1213,7 @@ function main() {
     fs.writeFileSync(path.join(DIST, 'CNAME'), `${SITE_DOMAIN}\n`);
   }
   writeSeoFiles();
-  fs.writeFileSync(path.join(DIST, 'site-map.json'), JSON.stringify({ base: BASE, domain: SITE_DOMAIN || null, pages: ['', ...docs.map((doc) => doc.slug)] }, null, 2));
+  fs.writeFileSync(path.join(DIST, 'site-map.json'), JSON.stringify({ base: BASE, domain: SITE_DOMAIN || null, pages: ['', 'benchmarks', ...docs.map((doc) => doc.slug)] }, null, 2));
   console.log(`Built Nidus site at ${path.relative(ROOT, DIST)} with base ${BASE}${SITE_DOMAIN ? ` and domain ${SITE_DOMAIN}` : ''}`);
 }
 

--- a/website/scripts/check-benchmarks.mjs
+++ b/website/scripts/check-benchmarks.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, '../dist');
+const failures = [];
+
+function readDist(route) {
+  const file = route === '/' ? path.join(DIST, 'index.html') : path.join(DIST, route, 'index.html');
+  if (!fs.existsSync(file)) {
+    failures.push(`${route}: missing generated HTML`);
+    return '';
+  }
+  return fs.readFileSync(file, 'utf8');
+}
+
+function assertIncludes(route, html, value) {
+  if (!html.includes(value)) failures.push(`${route}: missing ${value}`);
+}
+
+function assertExcludes(route, html, value) {
+  if (html.toLowerCase().includes(value.toLowerCase())) failures.push(`${route}: forbidden resource-usage wording ${value}`);
+}
+
+const home = readDist('/');
+const benchmarks = readDist('benchmarks');
+const siteMapPath = path.join(DIST, 'site-map.json');
+const siteMap = fs.existsSync(siteMapPath) ? JSON.parse(fs.readFileSync(siteMapPath, 'utf8')) : { pages: [] };
+const base = siteMap.base === '/' ? '/' : siteMap.base;
+
+assertIncludes('/', home, 'Benchmark evidence');
+assertIncludes('/', home, '/benchmarks/');
+assertIncludes('/', home, '423.72us');
+assertIncludes('/', home, '0.00% failed');
+
+assertIncludes('benchmarks', benchmarks, 'Nidus Framework Benchmark');
+assertIncludes('benchmarks', benchmarks, 'Bounded homelab run');
+assertIncludes('benchmarks', benchmarks, 'rust-nidus');
+assertIncludes('benchmarks', benchmarks, 'python-fastapi');
+assertIncludes('benchmarks', benchmarks, 'java-spring');
+assertIncludes('benchmarks', benchmarks, 'node-express');
+assertIncludes('benchmarks', benchmarks, '423.939646/s');
+assertIncludes('benchmarks', benchmarks, 'not a max-throughput or capacity ceiling');
+
+for (const route of ['/', 'benchmarks']) {
+  const html = route === '/' ? home : benchmarks;
+  assertExcludes(route, html, 'Resource Consumption');
+  assertExcludes(route, html, 'Peak CPU');
+  assertExcludes(route, html, 'Peak memory');
+  assertExcludes(route, html, '2Mi');
+  assertExcludes(route, html, '44m');
+}
+
+if (!siteMap.pages.includes('benchmarks')) failures.push('site-map.json: benchmarks route is missing');
+
+function contentType(file) {
+  if (file.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (file.endsWith('.css')) return 'text/css; charset=utf-8';
+  if (file.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (file.endsWith('.png')) return 'image/png';
+  return 'application/octet-stream';
+}
+
+function serveDist() {
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+    let pathname = decodeURIComponent(url.pathname);
+    if (base !== '/' && pathname.startsWith(base)) {
+      pathname = `/${pathname.slice(base.length)}`;
+    }
+    const normalized = pathname === '/' ? '/index.html' : pathname;
+    const candidate = path.normalize(path.join(DIST, normalized));
+    if (!candidate.startsWith(DIST)) {
+      response.writeHead(403).end();
+      return;
+    }
+    const file = fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()
+      ? path.join(candidate, 'index.html')
+      : candidate;
+    if (!fs.existsSync(file)) {
+      response.writeHead(404).end();
+      return;
+    }
+    response.writeHead(200, { 'content-type': contentType(file) });
+    fs.createReadStream(file).pipe(response);
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({ server, url: `http://127.0.0.1:${address.port}/` });
+    });
+  });
+}
+
+async function checkHomepageBenchmarkLayout() {
+  const { chromium } = await import(process.env.PLAYWRIGHT_MODULE_PATH ?? 'playwright');
+  const { server, url } = await serveDist();
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    for (const viewport of [
+      { name: 'desktop', width: 1440, height: 1000 },
+      { name: 'tablet', width: 820, height: 1180 },
+      { name: 'phone', width: 390, height: 844 },
+      { name: 'narrow phone', width: 320, height: 568 },
+    ]) {
+      const page = await browser.newPage({ viewport });
+      await page.goto(new URL(base, url).href, { waitUntil: 'networkidle' });
+      const result = await page.evaluate(() => {
+        const section = document.querySelector('.benchmark-teaser');
+        const ledger = document.querySelector('.benchmark-ledger');
+        const articleResults = [...document.querySelectorAll('.benchmark-ledger article')].map((article) => {
+          const articleBox = article.getBoundingClientRect();
+          const value = article.querySelector('strong');
+          const detail = article.querySelector('p');
+          const valueBox = value?.getBoundingClientRect();
+          const detailBox = detail?.getBoundingClientRect();
+          return {
+            article: {
+              left: articleBox.left,
+              right: articleBox.right,
+              width: articleBox.width,
+              scrollWidth: article.scrollWidth,
+              clientWidth: article.clientWidth,
+            },
+            value: valueBox ? { left: valueBox.left, right: valueBox.right, top: valueBox.top, bottom: valueBox.bottom, width: valueBox.width } : null,
+            detail: detailBox ? { left: detailBox.left, right: detailBox.right, top: detailBox.top, bottom: detailBox.bottom, width: detailBox.width } : null,
+          };
+        });
+        const sectionBox = section?.getBoundingClientRect();
+        const ledgerBox = ledger?.getBoundingClientRect();
+        return {
+          viewportWidth: innerWidth,
+          pageWidth: document.documentElement.scrollWidth,
+          section: sectionBox ? { left: sectionBox.left, right: sectionBox.right } : null,
+          ledger: ledgerBox ? { left: ledgerBox.left, right: ledgerBox.right } : null,
+          articles: articleResults,
+        };
+      });
+      await page.close();
+
+      const label = `homepage benchmark ${viewport.name}`;
+      if (result.pageWidth > result.viewportWidth) {
+        failures.push(`${label}: horizontal page overflow ${result.pageWidth}px > ${result.viewportWidth}px`);
+      }
+      if (!result.section || result.section.left < 0 || result.section.right > result.viewportWidth) {
+        failures.push(`${label}: section escapes viewport`);
+      }
+      if (!result.ledger || result.ledger.left < 0 || result.ledger.right > result.viewportWidth) {
+        failures.push(`${label}: ledger escapes viewport`);
+      }
+      for (const [index, item] of result.articles.entries()) {
+        if (!item.value) failures.push(`${label}: metric ${index + 1} value is missing`);
+        if (!item.detail) failures.push(`${label}: metric ${index + 1} detail is missing`);
+        if (item.article.scrollWidth > item.article.clientWidth + 1) {
+          failures.push(`${label}: metric ${index + 1} content overflows its cell`);
+        }
+        if (item.value && (item.value.left < item.article.left - 1 || item.value.right > item.article.right + 1)) {
+          failures.push(`${label}: metric ${index + 1} value escapes its cell`);
+        }
+        if (item.detail && (item.detail.left < item.article.left - 1 || item.detail.right > item.article.right + 1)) {
+          failures.push(`${label}: metric ${index + 1} detail escapes its cell`);
+        }
+        const sameRow = item.value && item.detail && item.value.bottom > item.detail.top && item.detail.bottom > item.value.top;
+        if (sameRow && item.value.right > item.detail.left - 12) {
+          failures.push(`${label}: metric ${index + 1} value crowds the detail text`);
+        }
+      }
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+await checkHomepageBenchmarkLayout();
+
+if (failures.length) {
+  console.error('Benchmark content check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Checked public benchmark route, homepage entry point, nav links, and omitted resource usage wording.');

--- a/website/scripts/check-mobile-layout.mjs
+++ b/website/scripts/check-mobile-layout.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, '../dist');
+const playwrightSpecifier = process.env.PLAYWRIGHT_MODULE_PATH ?? 'playwright';
+const siteMap = JSON.parse(fs.readFileSync(path.join(DIST, 'site-map.json'), 'utf8'));
+
+function contentType(file) {
+  if (file.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (file.endsWith('.css')) return 'text/css; charset=utf-8';
+  if (file.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (file.endsWith('.png')) return 'image/png';
+  if (file.endsWith('.json')) return 'application/json; charset=utf-8';
+  return 'application/octet-stream';
+}
+
+function serveDist() {
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+    const pathname = decodeURIComponent(url.pathname);
+    const normalized = pathname === '/' ? '/index.html' : pathname;
+    const candidate = path.normalize(path.join(DIST, normalized));
+    if (!candidate.startsWith(DIST)) {
+      response.writeHead(403).end();
+      return;
+    }
+    const file = fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()
+      ? path.join(candidate, 'index.html')
+      : candidate;
+    if (!fs.existsSync(file)) {
+      response.writeHead(404).end();
+      return;
+    }
+    response.writeHead(200, { 'content-type': contentType(file) });
+    fs.createReadStream(file).pipe(response);
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({ server, url: `http://127.0.0.1:${address.port}/` });
+    });
+  });
+}
+
+function isTransparent(value) {
+  return value === 'rgba(0, 0, 0, 0)' || value === 'transparent';
+}
+
+const viewports = [
+  { name: 'narrow phone', width: 320, height: 568 },
+  { name: 'iPhone portrait', width: 390, height: 844 },
+  { name: 'reported viewport', width: 402, height: 874 },
+  { name: 'large phone', width: 430, height: 932 },
+];
+
+const failures = [];
+const { chromium } = await import(playwrightSpecifier);
+const { server, url } = await serveDist();
+const browser = await chromium.launch({ headless: true });
+
+try {
+  for (const viewport of viewports) {
+    const page = await browser.newPage({
+      viewport: { width: viewport.width, height: viewport.height },
+      deviceScaleFactor: 3,
+      isMobile: true,
+      hasTouch: true,
+    });
+    await page.goto(url, { waitUntil: 'networkidle' });
+    const result = await page.evaluate(() => {
+      const rect = (selector) => {
+        const element = document.querySelector(selector);
+        if (!element) return null;
+        const box = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return {
+          x: box.x,
+          y: box.y,
+          width: box.width,
+          height: box.height,
+          right: box.right,
+          bottom: box.bottom,
+          display: style.display,
+          borderTopColor: style.borderTopColor,
+          backgroundColor: style.backgroundColor,
+        };
+      };
+      return {
+        viewport: { width: innerWidth, height: innerHeight },
+        scrollWidth: document.documentElement.scrollWidth,
+        header: rect('.site-header'),
+        mobileMark: rect('.mobile-hero-mark'),
+        desktopHeroMark: rect('.hero-proof > img'),
+        actions: rect('.hero-actions'),
+        buttons: [...document.querySelectorAll('.hero-actions .button')].map((button) => {
+          const box = button.getBoundingClientRect();
+          const style = getComputedStyle(button);
+          return {
+            text: button.textContent.trim(),
+            width: box.width,
+            height: box.height,
+            borderTopColor: style.borderTopColor,
+            backgroundColor: style.backgroundColor,
+          };
+        }),
+      };
+    });
+
+    const label = `${viewport.name} ${viewport.width}x${viewport.height}`;
+    if (result.scrollWidth > result.viewport.width) {
+      failures.push(`${label}: horizontal overflow ${result.scrollWidth}px > ${result.viewport.width}px`);
+    }
+    if (!result.header || result.header.x < 0 || result.header.right > result.viewport.width) {
+      failures.push(`${label}: header escapes viewport`);
+    }
+    if (!result.mobileMark || result.mobileMark.display === 'none') {
+      failures.push(`${label}: mobile hero mark is missing`);
+    } else {
+      if (result.mobileMark.x < 0 || result.mobileMark.right > result.viewport.width) {
+        failures.push(`${label}: mobile hero mark escapes horizontally`);
+      }
+      if (result.mobileMark.y < 0 || result.mobileMark.bottom > result.viewport.height - 16) {
+        failures.push(`${label}: mobile hero mark is clipped in the first viewport`);
+      }
+    }
+    if (result.desktopHeroMark && result.desktopHeroMark.display !== 'none') {
+      failures.push(`${label}: desktop hero art is still visible on phone layout`);
+    }
+    if (!result.actions || result.actions.height > 126) {
+      failures.push(`${label}: hero actions are too tall for mobile (${result.actions?.height ?? 'missing'}px)`);
+    }
+    for (const button of result.buttons) {
+      if (button.height < 44) failures.push(`${label}: ${button.text} touch target is shorter than 44px`);
+      if (isTransparent(button.borderTopColor) && isTransparent(button.backgroundColor)) {
+        failures.push(`${label}: ${button.text} has no visible mobile button affordance`);
+      }
+    }
+
+    for (const route of siteMap.pages) {
+      const routePath = route ? `${route}/` : '';
+      await page.goto(new URL(routePath, url).href, { waitUntil: 'networkidle' });
+      const pageResult = await page.evaluate(() => {
+        const header = document.querySelector('.site-header')?.getBoundingClientRect();
+        return {
+          pathname: location.pathname,
+          viewportWidth: innerWidth,
+          scrollWidth: document.documentElement.scrollWidth,
+          header: header
+            ? { x: header.x, right: header.right, width: header.width }
+            : null,
+        };
+      });
+      const routeLabel = `${label} ${pageResult.pathname}`;
+      if (pageResult.scrollWidth > pageResult.viewportWidth) {
+        failures.push(`${routeLabel}: horizontal overflow ${pageResult.scrollWidth}px > ${pageResult.viewportWidth}px`);
+      }
+      if (!pageResult.header || pageResult.header.x < 0 || pageResult.header.right > pageResult.viewportWidth) {
+        failures.push(`${routeLabel}: header escapes viewport`);
+      }
+    }
+    await page.close();
+  }
+} finally {
+  await browser.close();
+  server.close();
+}
+
+if (failures.length) {
+  console.error('Mobile layout check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Checked ${viewports.length} mobile viewport layouts and ${siteMap.pages.length} generated routes; no clipping, overflow, or CTA regressions.`);

--- a/website/scripts/check-seo.mjs
+++ b/website/scripts/check-seo.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, '../dist');
+const sitemap = JSON.parse(fs.readFileSync(path.join(DIST, 'site-map.json'), 'utf8'));
+const domain = sitemap.domain;
+const failures = [];
+
+if (!domain) {
+  failures.push('site-map.json domain is empty; run the SEO check against the canonical domain build');
+}
+
+const origin = domain ? `https://${domain}` : '';
+const expectedPages = sitemap.pages.map((page) => `/${page ? `${page}/` : ''}`);
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (entry.name.endsWith('.html')) files.push(full);
+  }
+  return files;
+}
+
+function attrsFor(html, tag, attrName, attrValue) {
+  const pattern = new RegExp(`<${tag}[^>]*\\s${attrName}="${attrValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[^>]*>`, 'i');
+  const match = pattern.exec(html);
+  if (!match) return null;
+  return Object.fromEntries([...match[0].matchAll(/([a-zA-Z:-]+)="([^"]*)"/g)].map((entry) => [entry[1], entry[2]]));
+}
+
+function metaContent(html, property) {
+  return attrsFor(html, 'meta', 'property', property)?.content
+    ?? attrsFor(html, 'meta', 'name', property)?.content
+    ?? null;
+}
+
+function linkHref(html, rel) {
+  return attrsFor(html, 'link', 'rel', rel)?.href ?? null;
+}
+
+function routeFromFile(file) {
+  const relative = path.relative(DIST, file);
+  if (relative === 'index.html') return '/';
+  if (relative === '404.html') return '/404.html';
+  return `/${relative.replace(/index\.html$/, '').replaceAll(path.sep, '/')}`;
+}
+
+function assertAbsoluteUrl(label, value) {
+  if (!value) {
+    failures.push(`${label} is missing`);
+    return;
+  }
+  if (!value.startsWith(`${origin}/`)) failures.push(`${label} must be absolute on ${origin}, found ${value}`);
+}
+
+for (const file of walk(DIST)) {
+  const html = fs.readFileSync(file, 'utf8');
+  const route = routeFromFile(file);
+  const canonicalRoute = route === '/404.html' ? '/' : route;
+  const expectedUrl = `${origin}${canonicalRoute}`;
+  const title = /<title>([^<]+)<\/title>/.exec(html)?.[1];
+  const description = metaContent(html, 'description');
+
+  if (!title || title.length < 12 || title.length > 70) failures.push(`${route}: title length should be 12-70 chars`);
+  if (!description || description.length < 50 || description.length > 170) failures.push(`${route}: description length should be 50-170 chars`);
+  if (linkHref(html, 'canonical') !== expectedUrl) failures.push(`${route}: canonical should be ${expectedUrl}`);
+  if (!html.includes(`<link rel="alternate" hreflang="en" href="${expectedUrl}">`)) failures.push(`${route}: English hreflang alternate should be ${expectedUrl}`);
+  if (!html.includes(`<link rel="alternate" hreflang="x-default" href="${expectedUrl}">`)) failures.push(`${route}: x-default hreflang alternate should be ${expectedUrl}`);
+  if (metaContent(html, 'og:url') !== expectedUrl) failures.push(`${route}: og:url should be ${expectedUrl}`);
+  if (metaContent(html, 'og:title') !== title) failures.push(`${route}: og:title should match <title>`);
+  if (metaContent(html, 'og:description') !== description) failures.push(`${route}: og:description should match meta description`);
+  if (metaContent(html, 'og:type') !== 'website') failures.push(`${route}: og:type should be website`);
+  if (metaContent(html, 'og:site_name') !== 'Nidus') failures.push(`${route}: og:site_name should be Nidus`);
+  if (metaContent(html, 'og:image:width') !== '1200') failures.push(`${route}: og:image:width should be 1200`);
+  if (metaContent(html, 'og:image:height') !== '630') failures.push(`${route}: og:image:height should be 630`);
+  if (metaContent(html, 'og:image:alt') !== 'Nidus Rust backend framework') failures.push(`${route}: og:image:alt is missing or incorrect`);
+  assertAbsoluteUrl(`${route}: og:image`, metaContent(html, 'og:image'));
+  if (metaContent(html, 'twitter:card') !== 'summary_large_image') failures.push(`${route}: twitter:card should be summary_large_image`);
+  if (metaContent(html, 'twitter:title') !== title) failures.push(`${route}: twitter:title should match <title>`);
+  if (metaContent(html, 'twitter:description') !== description) failures.push(`${route}: twitter:description should match meta description`);
+  assertAbsoluteUrl(`${route}: twitter:image`, metaContent(html, 'twitter:image'));
+  if (!html.includes('<script type="application/ld+json">')) failures.push(`${route}: JSON-LD structured data is missing`);
+}
+
+const robotsPath = path.join(DIST, 'robots.txt');
+if (!fs.existsSync(robotsPath)) {
+  failures.push('robots.txt is missing');
+} else {
+  const robots = fs.readFileSync(robotsPath, 'utf8');
+  if (!robots.includes(`Sitemap: ${origin}/sitemap.xml`)) failures.push('robots.txt must point to the canonical sitemap.xml');
+}
+
+const sitemapPath = path.join(DIST, 'sitemap.xml');
+if (!fs.existsSync(sitemapPath)) {
+  failures.push('sitemap.xml is missing');
+} else {
+  const xml = fs.readFileSync(sitemapPath, 'utf8');
+  for (const page of expectedPages) {
+    const loc = `<loc>${origin}${page}</loc>`;
+    if (!xml.includes(loc)) failures.push(`sitemap.xml is missing ${loc}`);
+  }
+}
+
+if (failures.length) {
+  console.error('SEO check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Checked SEO metadata for ${expectedPages.length} canonical pages on ${origin}.`);

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -201,6 +201,10 @@ pre {
   min-width: 0;
 }
 
+.mobile-hero-mark {
+  display: none;
+}
+
 .eyebrow,
 .doc-kicker,
 .docs-sidebar label,
@@ -1058,6 +1062,7 @@ a:focus-visible {
 @media (max-width: 840px) {
   body {
     font-size: 16px;
+    background-size: 72px 72px, 72px 72px, auto;
   }
 
   .site-header {
@@ -1101,9 +1106,9 @@ a:focus-visible {
 
   .hero {
     min-height: auto;
-    gap: var(--space-2xl);
-    padding: var(--space-3xl) 0 var(--space-2xl);
-    overflow: hidden;
+    gap: var(--space-xl);
+    padding: var(--space-2xl) 0 var(--space-xl);
+    overflow: visible;
   }
 
   .hero::after,
@@ -1127,15 +1132,35 @@ a:focus-visible {
   }
 
   .hero-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: stretch;
+    gap: var(--space-sm);
+    margin-top: var(--space-xl);
   }
 
   .button {
-    flex: 1 1 150px;
+    width: 100%;
+    min-height: 48px;
+    padding-inline: var(--space-md);
+  }
+
+  .hero-actions .button.ghost {
+    border-color: color-mix(in oklch, var(--line), var(--brand) 18%);
+    background: color-mix(in oklch, var(--panel), var(--brand-tint) 18%);
+    color: var(--muted);
+  }
+
+  .mobile-hero-mark {
+    display: block;
+    width: min(58vw, 210px);
+    height: auto;
+    margin: var(--space-lg) auto var(--space-xl);
+    filter: drop-shadow(0 18px 28px oklch(28% 0.08 296 / 0.16));
   }
 
   .hero-proof img {
-    width: min(100%, 260px);
+    display: none;
   }
 
   .hero-proof pre,
@@ -1218,10 +1243,10 @@ a:focus-visible {
   .proof-band,
   .docs-frame,
   .footer-inner {
-    width: min(366px, calc(100vw - 24px));
-    max-width: 366px;
-    margin-left: 12px;
-    margin-right: 12px;
+    width: calc(100vw - 24px);
+    max-width: calc(100vw - 24px);
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .brand {
@@ -1239,15 +1264,6 @@ a:focus-visible {
 
   h2 {
     font-size: 2rem;
-  }
-
-  .hero-actions {
-    flex-direction: column;
-  }
-
-  .button {
-    width: 100%;
-    flex: 0 0 auto;
   }
 
   .concept-model,

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -407,6 +407,7 @@ h3 {
 .surface-table,
 .adapter-story,
 .example-panel,
+.benchmark-teaser,
 .proof-band {
   width: min(var(--max), calc(100% - 32px));
   margin: 0 auto;
@@ -482,6 +483,7 @@ h3 {
 .surface-table,
 .adapter-story,
 .example-panel,
+.benchmark-teaser,
 .proof-band {
   padding: var(--space-5xl) 0;
 }
@@ -627,6 +629,215 @@ h3 {
   color: var(--brand-soft);
   font-weight: 760;
   text-decoration: none;
+}
+
+.benchmark-teaser {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.52fr) minmax(0, 0.9fr);
+  gap: var(--space-4xl);
+  align-items: center;
+}
+
+.benchmark-teaser-copy p,
+.benchmark-run-card p,
+.benchmark-method p,
+.benchmark-results-heading p,
+.benchmark-interpretation p {
+  color: var(--muted);
+}
+
+.benchmark-ledger {
+  display: grid;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: color-mix(in oklch, var(--panel), transparent 6%);
+}
+
+.benchmark-ledger article {
+  display: grid;
+  grid-template-columns: minmax(124px, 0.24fr) minmax(0, 1fr);
+  gap: var(--space-sm);
+  align-items: start;
+  min-height: 148px;
+  padding: var(--space-xl) var(--space-2xl);
+}
+
+.benchmark-ledger article + article {
+  border-top: 1px solid var(--line-soft);
+}
+
+.benchmark-ledger article:nth-child(2) {
+  background: color-mix(in oklch, var(--brand-tint), var(--panel) 54%);
+}
+
+.benchmark-ledger span,
+.benchmark-run-card span {
+  color: var(--copper);
+  font-size: 0.82rem;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.benchmark-ledger span {
+  grid-row: 1 / span 2;
+  padding-top: 0.34rem;
+}
+
+.benchmark-ledger strong {
+  color: var(--ink);
+  font-family: "Bricolage Grotesque", "Afacad Flux", sans-serif;
+  font-size: clamp(2.35rem, 3.4vw, 3.55rem);
+  font-variant-numeric: tabular-nums;
+  line-height: 0.96;
+  white-space: nowrap;
+}
+
+.benchmark-ledger p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.38;
+  max-width: 44ch;
+}
+
+.benchmark-page {
+  width: min(var(--max), calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.benchmark-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(280px, 0.45fr);
+  gap: var(--space-4xl);
+  align-items: end;
+  padding: var(--space-4xl) 0 var(--space-3xl);
+  border-bottom: 1px solid var(--line);
+}
+
+.benchmark-hero h1 {
+  max-width: 11ch;
+  font-size: clamp(4rem, 9vw, 7rem);
+}
+
+.benchmark-hero p {
+  max-width: 64ch;
+  color: var(--muted);
+  font-size: 1.22rem;
+}
+
+.benchmark-run-card {
+  display: grid;
+  gap: var(--space-md);
+  border: 1px solid color-mix(in oklch, var(--brand), var(--line) 48%);
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--brand-tint), var(--panel) 58%);
+  padding: var(--space-xl);
+}
+
+.benchmark-run-card strong {
+  color: var(--ink);
+  font-family: "Bricolage Grotesque", "Afacad Flux", sans-serif;
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.benchmark-run-card p {
+  margin: 0;
+}
+
+.benchmark-method,
+.benchmark-results,
+.benchmark-interpretation {
+  padding: var(--space-5xl) 0;
+}
+
+.benchmark-method {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.56fr) minmax(0, 1fr);
+  gap: var(--space-4xl);
+  align-items: start;
+}
+
+.benchmark-method-grid,
+.benchmark-interpretation-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+
+.benchmark-method-grid article,
+.benchmark-interpretation-list article {
+  border-top: 1px solid var(--line);
+  padding-top: var(--space-lg);
+}
+
+.benchmark-results-heading {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.62fr) minmax(0, 0.55fr);
+  gap: var(--space-3xl);
+  align-items: end;
+  margin-bottom: var(--space-2xl);
+}
+
+.benchmark-results-heading p {
+  margin-bottom: var(--space-lg);
+}
+
+.benchmark-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+.benchmark-table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+.benchmark-table th,
+.benchmark-table td {
+  border-bottom: 1px solid var(--line-soft);
+  padding: var(--space-md);
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.benchmark-table th {
+  color: var(--ink);
+  background: color-mix(in oklch, var(--panel-2), var(--panel) 48%);
+  font-size: 0.86rem;
+  font-weight: 760;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.benchmark-table tbody tr:nth-child(4n + 1),
+.benchmark-table tbody tr:nth-child(4n + 2),
+.benchmark-table tbody tr:nth-child(4n + 3),
+.benchmark-table tbody tr:nth-child(4n + 4) {
+  background: color-mix(in oklch, var(--panel), transparent 8%);
+}
+
+.benchmark-table tbody tr:nth-child(8n + 1),
+.benchmark-table tbody tr:nth-child(8n + 2),
+.benchmark-table tbody tr:nth-child(8n + 3),
+.benchmark-table tbody tr:nth-child(8n + 4) {
+  background: color-mix(in oklch, var(--brand-tint), var(--panel) 72%);
+}
+
+.benchmark-table code {
+  color: var(--ink);
+}
+
+.benchmark-interpretation {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.5fr) minmax(0, 1fr);
+  gap: var(--space-4xl);
+  border-top: 1px solid var(--line);
 }
 
 .proof-list {
@@ -1010,6 +1221,11 @@ a:focus-visible {
   .first-minute,
   .surface-table,
   .adapter-story,
+  .benchmark-teaser,
+  .benchmark-hero,
+  .benchmark-method,
+  .benchmark-results-heading,
+  .benchmark-interpretation,
   .example-panel {
     grid-template-columns: 1fr;
   }
@@ -1021,6 +1237,8 @@ a:focus-visible {
   .minute-links,
   .model-flow,
   .example-paths,
+  .benchmark-method-grid,
+  .benchmark-interpretation-list,
   .proof-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1097,6 +1315,8 @@ a:focus-visible {
   .surface-table,
   .adapter-story,
   .example-panel,
+  .benchmark-teaser,
+  .benchmark-page,
   .proof-band,
   .docs-frame,
   .footer-inner {
@@ -1185,6 +1405,8 @@ a:focus-visible {
   .minute-links,
   .model-flow,
   .example-paths,
+  .benchmark-method-grid,
+  .benchmark-interpretation-list,
   .proof-list {
     grid-template-columns: 1fr;
   }
@@ -1193,6 +1415,35 @@ a:focus-visible {
   .model-flow article + article {
     border-left: 0;
     border-top: 1px solid var(--line-soft);
+  }
+
+  .benchmark-ledger article {
+    grid-template-columns: 1fr;
+    align-items: start;
+    min-height: auto;
+  }
+
+  .benchmark-ledger strong {
+    font-size: clamp(1.9rem, 11vw, 2.5rem);
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .benchmark-ledger p {
+    max-width: 36ch;
+  }
+
+  .benchmark-hero {
+    gap: var(--space-xl);
+    padding: var(--space-3xl) 0 var(--space-2xl);
+  }
+
+  .benchmark-hero h1 {
+    max-width: none;
+  }
+
+  .benchmark-results-heading {
+    margin-bottom: var(--space-xl);
   }
 
   .surface-list a {
@@ -1240,6 +1491,8 @@ a:focus-visible {
   .surface-table,
   .adapter-story,
   .example-panel,
+  .benchmark-teaser,
+  .benchmark-page,
   .proof-band,
   .docs-frame,
   .footer-inner {
@@ -1270,12 +1523,17 @@ a:focus-visible {
   .surface-table,
   .adapter-story,
   .example-panel,
+  .benchmark-teaser,
+  .benchmark-method,
+  .benchmark-results,
+  .benchmark-interpretation,
   .proof-band {
     padding: var(--space-4xl) 0;
   }
 
   .minute-links a,
   .model-flow article,
+  .benchmark-ledger article,
   .docs-pager a {
     padding: var(--space-lg);
   }


### PR DESCRIPTION
## Summary
- fixes the Nidus website mobile hero/header layout and adds regression guards for phone viewports
- adds canonical rustnidus.com SEO metadata, Open Graph/Twitter card tags, JSON-LD, robots.txt, and sitemap.xml generation
- adds a homepage benchmark section and `/benchmarks/` page with bounded latency/throughput results while omitting resource-usage claims
- adds reproducible website checks for SEO, mobile layout, benchmark content, and benchmark responsive layout

## Validation
- npm run verify:domain
- npm run check-mobile
- npm run verify:project
- git diff --check

## Notes
Direct push to `main` was rejected by branch protection, so `codex/website-mobile-seo` is pushed for PR-based merge.
