### PR TITLE
fix(events): drop evicted values outside queue locks

### DIFF
--- a/crates/nidus-events/src/lib.rs
+++ b/crates/nidus-events/src/lib.rs
@@ -41,19 +41,26 @@ impl<T> Default for SubscriberBuffer<T> {
 }
 
 impl<T> SubscriberBuffer<T> {
-    fn push(&mut self, event: T) {
+    #[must_use]
+    fn push(&mut self, event: T) -> Option<T> {
         match &mut self.events {
-            SubscriberEvents::Unbounded(events) => events.push(event),
+            SubscriberEvents::Unbounded(events) => {
+                events.push(event);
+                None
+            }
             SubscriberEvents::Bounded { events, capacity } => {
                 if *capacity == 0 {
                     // A zero-capacity subscriber keeps nothing.
-                    return;
+                    return Some(event);
                 }
-                if events.len() == *capacity {
+                let evicted = if events.len() == *capacity {
                     // VecDeque makes oldest-event eviction constant-time.
-                    events.pop_front();
-                }
+                    events.pop_front()
+                } else {
+                    None
+                };
                 events.push_back(event);
+                evicted
             }
         }
     }
@@ -386,15 +393,31 @@ where
         };
 
         let Some(last) = additional.pop() else {
-            lock_unpoisoned(&first).push(event);
+            let evicted = {
+                let mut queue = lock_unpoisoned(&first);
+                queue.push(event)
+            };
+            drop(evicted);
             return;
         };
 
-        lock_unpoisoned(&first).push(event.clone());
+        let evicted = {
+            let mut queue = lock_unpoisoned(&first);
+            queue.push(event.clone())
+        };
+        drop(evicted);
         for subscriber in additional {
-            lock_unpoisoned(&subscriber).push(event.clone());
+            let evicted = {
+                let mut queue = lock_unpoisoned(&subscriber);
+                queue.push(event.clone())
+            };
+            drop(evicted);
         }
-        lock_unpoisoned(&last).push(event);
+        let evicted = {
+            let mut queue = lock_unpoisoned(&last);
+            queue.push(event)
+        };
+        drop(evicted);
     }
 
     /// Wraps this bus with an observer.
@@ -459,7 +482,15 @@ fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, thread};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        thread,
+        time::Duration,
+    };
 
     use super::*;
     use tracing::Level;
@@ -507,6 +538,57 @@ mod tests {
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct UserCreated(u64);
+
+    #[derive(Clone)]
+    struct DropActionEvent {
+        id: u64,
+        action: Option<Arc<dyn Fn() + Send + Sync>>,
+    }
+
+    impl DropActionEvent {
+        fn plain(id: u64) -> Self {
+            Self { id, action: None }
+        }
+
+        fn with_action(id: u64, action: impl Fn() + Send + Sync + 'static) -> Self {
+            Self {
+                id,
+                action: Some(Arc::new(action)),
+            }
+        }
+    }
+
+    impl Drop for DropActionEvent {
+        fn drop(&mut self) {
+            if let Some(action) = self.action.take() {
+                action();
+            }
+        }
+    }
+
+    struct PanicCloneEvent {
+        id: u64,
+        clone_calls: Arc<AtomicUsize>,
+        panic_on_call: usize,
+    }
+
+    impl PanicCloneEvent {
+        fn new(id: u64, clone_calls: Arc<AtomicUsize>, panic_on_call: usize) -> Self {
+            Self {
+                id,
+                clone_calls,
+                panic_on_call,
+            }
+        }
+    }
+
+    impl Clone for PanicCloneEvent {
+        fn clone(&self) -> Self {
+            let call = self.clone_calls.fetch_add(1, Ordering::Relaxed) + 1;
+            assert_ne!(call, self.panic_on_call, "injected clone panic");
+            Self::new(self.id, Arc::clone(&self.clone_calls), self.panic_on_call)
+        }
+    }
 
     #[test]
     fn event_bus_recovers_from_poisoned_subscriber_list() {
@@ -581,6 +663,54 @@ mod tests {
     }
 
     #[test]
+    fn first_clone_panic_poisoning_and_recovery_match_existing_contract() {
+        let bus = EventBus::<PanicCloneEvent>::new();
+        let first = bus.subscribe();
+        let last = bus.subscribe();
+        let clone_calls = Arc::new(AtomicUsize::new(0));
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bus.publish(PanicCloneEvent::new(1, Arc::clone(&clone_calls), 1));
+        }));
+
+        assert!(panic.is_err());
+        assert!(first.queue.lock().is_err());
+        assert!(last.queue.lock().is_ok());
+        assert!(first.drain().is_empty());
+        assert!(last.drain().is_empty());
+
+        bus.publish(PanicCloneEvent::new(2, Arc::clone(&clone_calls), 1));
+        assert_eq!(first.drain().pop().unwrap().id, 2);
+        assert_eq!(last.drain().pop().unwrap().id, 2);
+    }
+
+    #[test]
+    fn later_clone_panic_preserves_partial_delivery_and_recovers() {
+        let bus = EventBus::<PanicCloneEvent>::new();
+        let first = bus.subscribe();
+        let middle = bus.subscribe();
+        let last = bus.subscribe();
+        let clone_calls = Arc::new(AtomicUsize::new(0));
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bus.publish(PanicCloneEvent::new(1, Arc::clone(&clone_calls), 2));
+        }));
+
+        assert!(panic.is_err());
+        assert!(first.queue.lock().is_ok());
+        assert!(middle.queue.lock().is_err());
+        assert!(last.queue.lock().is_ok());
+        assert_eq!(first.drain().pop().unwrap().id, 1);
+        assert!(middle.drain().is_empty());
+        assert!(last.drain().is_empty());
+
+        bus.publish(PanicCloneEvent::new(2, Arc::clone(&clone_calls), 2));
+        assert_eq!(first.drain().pop().unwrap().id, 2);
+        assert_eq!(middle.drain().pop().unwrap().id, 2);
+        assert_eq!(last.drain().pop().unwrap().id, 2);
+    }
+
+    #[test]
     fn bounded_subscriber_drops_oldest_events_beyond_capacity() {
         let bus = EventBus::<UserCreated>::new();
         let bounded = bus.subscribe_with_capacity(2);
@@ -598,6 +728,119 @@ mod tests {
         bus.publish(UserCreated(5));
         bus.publish(UserCreated(6));
         assert_eq!(bounded.drain(), vec![UserCreated(5), UserCreated(6)]);
+    }
+
+    #[test]
+    fn bounded_eviction_drops_reentrant_payload_after_unlocking_queue() {
+        let bus = EventBus::<DropActionEvent>::new();
+        let subscriber = bus.subscribe_with_capacity(1);
+        let reentrant_bus = bus.clone();
+        let reentrant_subscriber = subscriber.clone();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        bus.publish(DropActionEvent::with_action(1, move || {
+            reentrant_bus.publish(DropActionEvent::plain(3));
+            let ids = reentrant_subscriber
+                .drain()
+                .into_iter()
+                .map(|event| event.id)
+                .collect::<Vec<_>>();
+            result_tx.send(ids).unwrap();
+        }));
+        bus.publish(DropActionEvent::plain(2));
+
+        assert_eq!(
+            result_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            vec![3]
+        );
+        assert!(subscriber.drain().is_empty());
+    }
+
+    #[test]
+    fn zero_capacity_rejection_drops_reentrant_payload_after_unlocking_queue() {
+        let bus = EventBus::<DropActionEvent>::new();
+        let subscriber = bus.subscribe_with_capacity(0);
+        let reentrant_bus = bus.clone();
+        let (dropped_tx, dropped_rx) = mpsc::channel();
+
+        bus.publish(DropActionEvent::with_action(1, move || {
+            reentrant_bus.publish(DropActionEvent::plain(2));
+            dropped_tx.send(()).unwrap();
+        }));
+
+        dropped_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(subscriber.drain().is_empty());
+    }
+
+    #[test]
+    fn bounded_eviction_drop_panic_does_not_poison_queue() {
+        let bus = EventBus::<DropActionEvent>::new();
+        let subscriber = bus.subscribe_with_capacity(1);
+        bus.publish(DropActionEvent::with_action(1, || {
+            panic!("panic from evicted payload destructor");
+        }));
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bus.publish(DropActionEvent::plain(2));
+        }));
+
+        assert!(panic.is_err());
+        assert!(subscriber.queue.lock().is_ok());
+        assert_eq!(
+            subscriber
+                .drain()
+                .into_iter()
+                .map(|event| event.id)
+                .collect::<Vec<_>>(),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn bounded_eviction_slow_drop_does_not_hold_queue_lock() {
+        let bus = EventBus::<DropActionEvent>::new();
+        let subscriber = bus.subscribe_with_capacity(1);
+        let (drop_started_tx, drop_started_rx) = mpsc::channel();
+        let (release_drop_tx, release_drop_rx) = mpsc::channel();
+        let release_drop_rx = Arc::new(Mutex::new(release_drop_rx));
+
+        bus.publish(DropActionEvent::with_action(1, move || {
+            drop_started_tx.send(()).unwrap();
+            release_drop_rx
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+        }));
+
+        let publisher = {
+            let bus = bus.clone();
+            thread::spawn(move || bus.publish(DropActionEvent::plain(2)))
+        };
+        drop_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+
+        let (drained_tx, drained_rx) = mpsc::channel();
+        let drainer = {
+            let subscriber = subscriber.clone();
+            thread::spawn(move || {
+                let ids = subscriber
+                    .drain()
+                    .into_iter()
+                    .map(|event| event.id)
+                    .collect::<Vec<_>>();
+                drained_tx.send(ids).unwrap();
+            })
+        };
+
+        assert_eq!(
+            drained_rx.recv_timeout(Duration::from_millis(250)).unwrap(),
+            vec![2]
+        );
+        release_drop_tx.send(()).unwrap();
+        publisher.join().unwrap();
+        drainer.join().unwrap();
     }
 
     #[test]

--- a/crates/nidus-events/tests/events.rs
+++ b/crates/nidus-events/tests/events.rs
@@ -1,6 +1,10 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
 };
 
 use nidus_events::EventBus;
@@ -105,4 +109,123 @@ fn event_bus_moves_to_one_subscriber_and_clones_only_for_additional_subscribers(
             .collect::<Vec<_>>(),
         vec![2]
     );
+}
+
+#[test]
+fn cloned_subscriber_handles_share_one_queue_without_duplication() {
+    let bus = EventBus::<u64>::new();
+    let first_handle = bus.subscribe();
+    let second_handle = first_handle.clone();
+    for event in 0..10_000 {
+        bus.publish(event);
+    }
+
+    let first = thread::spawn(move || first_handle.drain());
+    let second = thread::spawn(move || second_handle.drain());
+    let mut combined = first.join().unwrap();
+    combined.extend(second.join().unwrap());
+    combined.sort_unstable();
+
+    assert_eq!(combined, (0..10_000).collect::<Vec<_>>());
+}
+
+#[test]
+fn concurrent_publishers_preserve_per_publisher_order_without_duplication() {
+    const PUBLISHERS: u16 = 4;
+    const EVENTS: u16 = 2_000;
+    let bus = EventBus::<(u16, u16)>::new();
+    let subscribers = (0..4).map(|_| bus.subscribe()).collect::<Vec<_>>();
+    let barrier = Arc::new(Barrier::new(PUBLISHERS as usize));
+    let publishers = (0..PUBLISHERS)
+        .map(|publisher| {
+            let bus = bus.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for sequence in 0..EVENTS {
+                    bus.publish((publisher, sequence));
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for publisher in publishers {
+        publisher.join().unwrap();
+    }
+
+    let expected = (0..PUBLISHERS)
+        .flat_map(|publisher| (0..EVENTS).map(move |sequence| (publisher, sequence)))
+        .collect::<Vec<_>>();
+    for subscriber in subscribers {
+        let delivered = subscriber.drain();
+        assert_eq!(delivered.len(), expected.len());
+        let mut sorted = delivered.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, expected);
+        for publisher in 0..PUBLISHERS {
+            let sequence = delivered
+                .iter()
+                .filter_map(|(candidate, sequence)| (*candidate == publisher).then_some(*sequence))
+                .collect::<Vec<_>>();
+            assert_eq!(sequence, (0..EVENTS).collect::<Vec<_>>());
+        }
+    }
+}
+
+#[test]
+fn generated_publish_drain_schedules_match_bounded_queue_model() {
+    // Keep the full deterministic property surface on native runners. Miri's
+    // interpreter exercises a representative subset so the memory-model pass
+    // remains bounded while using the same state machine and assertions.
+    let (seed_count, operations_per_seed) = if cfg!(miri) {
+        (4_u64, 200)
+    } else {
+        (64_u64, 2_000)
+    };
+    for capacity in [0, 1, 2, 16, 1024] {
+        for seed in 1..=seed_count {
+            let bus = EventBus::<u64>::new();
+            let subscriber = bus.subscribe_with_capacity(capacity);
+            let mut model = VecDeque::new();
+            let mut state = seed;
+            let mut next_event = 0u64;
+
+            for _ in 0..operations_per_seed {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                if state & 0b111 == 0 {
+                    assert_eq!(subscriber.drain(), model.drain(..).collect::<Vec<_>>());
+                } else {
+                    bus.publish(next_event);
+                    if capacity > 0 {
+                        if model.len() == capacity {
+                            model.pop_front();
+                        }
+                        model.push_back(next_event);
+                    }
+                    next_event += 1;
+                }
+            }
+
+            assert_eq!(subscriber.drain(), model.into_iter().collect::<Vec<_>>());
+        }
+    }
+}
+
+#[test]
+fn mixed_zero_and_nonzero_capacity_subscribers_preserve_newest_values() {
+    let bus = EventBus::<u64>::new();
+    let zero = bus.subscribe_with_capacity(0);
+    let one = bus.subscribe_with_capacity(1);
+    let sixteen = bus.subscribe_with_capacity(16);
+    let unbounded = bus.subscribe();
+
+    for event in 0..100 {
+        bus.publish(event);
+    }
+
+    assert!(zero.drain().is_empty());
+    assert_eq!(one.drain(), vec![99]);
+    assert_eq!(sixteen.drain(), (84..100).collect::<Vec<_>>());
+    assert_eq!(unbounded.drain(), (0..100).collect::<Vec<_>>());
 }

--- a/crates/nidus-events/tests/observed_events.rs
+++ b/crates/nidus-events/tests/observed_events.rs
@@ -1,4 +1,8 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex, mpsc},
+    thread,
+    time::Duration,
+};
 
 use nidus_events::{
     EventBus, EventObserver, ObservedEventBus, ObservedEventContext, event_observer_channel,
@@ -6,6 +10,8 @@ use nidus_events::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct UserCreated(u64);
+
+type ObservedDeliveries = Arc<Mutex<Vec<(String, Vec<UserCreated>)>>>;
 
 #[derive(Clone, Default)]
 struct RecordingObserver {
@@ -77,4 +83,116 @@ fn event_bus_observed_wraps_bus_without_repeating_type_names() {
 
     assert_eq!(subscriber.drain(), vec![UserCreated(44)]);
     assert_eq!(observer.events(), ["published user.created event-run-3"]);
+}
+
+#[derive(Clone)]
+struct DeliveryOrderObserver {
+    subscriber: nidus_events::EventSubscriber<UserCreated>,
+    observed: ObservedDeliveries,
+}
+
+impl EventObserver<UserCreated> for DeliveryOrderObserver {
+    fn on_event_published(&self, context: &ObservedEventContext) {
+        self.observed
+            .lock()
+            .unwrap()
+            .push((context.event_name().to_owned(), self.subscriber.drain()));
+    }
+}
+
+#[test]
+fn observer_runs_exactly_once_after_subscriber_delivery() {
+    let bus = EventBus::<UserCreated>::new();
+    let subscriber = bus.subscribe();
+    let observed_events = Arc::new(Mutex::new(Vec::new()));
+    let observed = bus
+        .observed(DeliveryOrderObserver {
+            subscriber: subscriber.clone(),
+            observed: Arc::clone(&observed_events),
+        })
+        .operation_id_generator(|| "event-order-1".to_owned());
+
+    observed.publish_named("user.created", UserCreated(45));
+
+    assert_eq!(
+        *observed_events.lock().unwrap(),
+        vec![("user.created".to_owned(), vec![UserCreated(45)])]
+    );
+    assert!(subscriber.drain().is_empty());
+}
+
+#[derive(Clone)]
+struct BlockingObserver {
+    entered: mpsc::Sender<()>,
+    release: Arc<Mutex<mpsc::Receiver<()>>>,
+}
+
+impl EventObserver<UserCreated> for BlockingObserver {
+    fn on_event_published(&self, _context: &ObservedEventContext) {
+        self.entered.send(()).unwrap();
+        self.release
+            .lock()
+            .unwrap()
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+    }
+}
+
+#[test]
+fn slow_observer_does_not_delay_already_completed_subscriber_delivery() {
+    let bus = EventBus::<UserCreated>::new();
+    let subscriber = bus.subscribe();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let observed = bus.observed(BlockingObserver {
+        entered: entered_tx,
+        release: Arc::new(Mutex::new(release_rx)),
+    });
+
+    let publisher = thread::spawn(move || {
+        observed.publish_named("user.created", UserCreated(46));
+    });
+    entered_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+    assert_eq!(subscriber.drain(), vec![UserCreated(46)]);
+    release_tx.send(()).unwrap();
+    publisher.join().unwrap();
+}
+
+#[derive(Clone)]
+struct PanickingObserver;
+
+impl EventObserver<UserCreated> for PanickingObserver {
+    fn on_event_published(&self, _context: &ObservedEventContext) {
+        panic!("panic from event observer");
+    }
+}
+
+#[test]
+fn panicking_observer_preserves_completed_delivery_and_future_bus_use() {
+    let bus = EventBus::<UserCreated>::new();
+    let subscriber = bus.subscribe();
+    let observed = bus.clone().observed(PanickingObserver);
+
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        observed.publish_named("user.created", UserCreated(47));
+    }));
+
+    assert!(panic.is_err());
+    assert_eq!(subscriber.drain(), vec![UserCreated(47)]);
+    bus.publish(UserCreated(48));
+    assert_eq!(subscriber.drain(), vec![UserCreated(48)]);
+}
+
+#[test]
+fn disconnected_channel_observer_remains_best_effort() {
+    let bus = EventBus::<UserCreated>::new();
+    let subscriber = bus.subscribe();
+    let (observer, receiver) = event_observer_channel();
+    drop(receiver);
+    let observed = bus.observed(observer);
+
+    observed.publish_named("user.created", UserCreated(49));
+
+    assert_eq!(subscriber.drain(), vec![UserCreated(49)]);
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -20,6 +20,12 @@ If a subscriber list or queue mutex is poisoned by a panic, the bus logs a
 warning and recovers the inner state so later subscribers and publishes can
 continue.
 
+When a full bounded queue evicts its oldest event, Nidus finishes the queue
+mutation and releases the queue mutex before destroying the evicted value. A
+slow, panicking, or reentrant event destructor therefore cannot run while that
+queue is locked. The drop-oldest policy, FIFO order, and owned drain contract
+are unchanged.
+
 ## Observed Events
 
 `ObservedEventBus` wraps an existing `EventBus` and records publication context

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -123,6 +123,33 @@ for specific framework behavior and should be compared to their own history.
 
 ## Local Results
 
+### Bounded Event Eviction Lock Scope (2026-07-22)
+
+When a bounded event subscriber reaches capacity, publication now removes the
+oldest value, installs the new value, and releases the subscriber queue mutex
+before destroying the evicted value. Zero-capacity subscribers follow the same
+rule: the rejected value is returned from the guarded queue operation and
+destroyed only after the guard is released.
+
+Previously, discarding the value returned by `VecDeque::pop_front` could run an
+arbitrary `T::drop` implementation while the subscriber queue remained locked.
+A slow destructor could unnecessarily extend the critical section, a reentrant
+destructor could deadlock while publishing or draining through the same queue,
+and a panicking destructor could poison the queue mutex. Queue mutation and
+payload destruction are now separate phases.
+
+The change preserves public signatures, FIFO order, drop-oldest capacity
+behavior, zero-capacity behavior, subscriber registration order, event clone
+counts, partial-delivery boundaries, observer ordering, and the owned
+`drain() -> Vec<T>` contract. Unbounded publication and bounded publication
+that does not evict an event retain their existing behavior.
+
+Focused regression coverage exercises reentrant destruction at capacities one
+and zero, blocked and panicking destructors, queue poison recovery, exact FIFO
+eviction, clone-panic partial delivery, concurrent publishers, and generated
+publish/drain schedules. The change is correctness and tail-latency isolation
+hardening rather than a general publication-throughput optimization.
+
 ### Borrowed configuration and lifecycle rollback pass (2026-07-20)
 
 `Config` previously cloned a complete `serde_json::Value` before every typed


### PR DESCRIPTION
## Summary

Describe the change and why it belongs in Nidus.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo doc --workspace --all-features --no-deps`
- [x] `cargo deny check`
- [x] `npm run verify` from `website/` when docs or site output changed
